### PR TITLE
Handle window minute columns when plotting coverage

### DIFF
--- a/tests/test_reporting_minimal.py
+++ b/tests/test_reporting_minimal.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
-from src import reporting
+import datetime as dt
+
+import numpy as np
+import pandas as pd
 import pytest
+
+from src import reporting
 
 
 def test_reporting_generates_files(sample_environment, tmp_path, monkeypatch):
@@ -44,3 +49,68 @@ def test_objective_breakdown_matches_solver(sample_environment, tmp_path, monkey
         report_row = report_df.loc[report_df["name"] == name]
         assert not report_row.empty, f"component {name} missing in report"
         assert pytest.approx(data.get("cost", 0.0)) == report_row.iloc[0]["contribution"]
+
+
+def test_plot_coverage_accepts_time_objects(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    reporter = reporting.ScheduleReporter(solver=None, cp_solver=None)
+
+    coverage_df = pd.DataFrame(
+        [
+            {
+                "segment_id": "seg-1",
+                "start_time": "09:00",
+                "end_time": "10:00",
+                "demand": 2,
+                "assigned": 0,
+                "shortfall": 2,
+                "overstaffing": 0,
+            }
+        ]
+    )
+
+    reporter.assignments_df = pd.DataFrame(
+        [
+            {
+                "employee": "emp-1",
+                "day": "2024-01-01",
+                "start_dt": pd.Timestamp("2024-01-01 09:00"),
+                "end_dt": pd.Timestamp("2024-01-01 10:00"),
+            }
+        ]
+    )
+
+    reporter.windows_df = pd.DataFrame(
+        [
+            {
+                "window_id": "win-1",
+                "day": "2024-01-01",
+                "window_start": dt.time(9, 0),
+                "window_end": dt.time(10, 0),
+                "window_start_min": 9 * 60,
+                "window_end_min": 10 * 60,
+                "window_demand": 2,
+            }
+        ]
+    )
+
+    created_arrays: list[np.ndarray] = []
+    original_zeros = np.zeros
+
+    def tracking_zeros(shape, dtype=float):
+        arr = original_zeros(shape, dtype=dtype)
+        created_arrays.append(arr)
+        return arr
+
+    monkeypatch.setattr(np, "zeros", tracking_zeros)
+
+    reporter._plot_coverage(coverage_df)
+
+    assert created_arrays, "expected demand matrix allocation"
+    demand_matrix = created_arrays[0]
+    assert demand_matrix.sum() > 0
+
+    plot_path = reporter.output_dir / "coverage_plot.png"
+    assert plot_path.exists()
+    assert plot_path.stat().st_size > 0


### PR DESCRIPTION
## Summary
- derive coverage slot indices from precomputed minute columns when available and retain robust parsing for time inputs when missing
- add a regression test that injects datetime.time windows to confirm coverage plotting populates demand and saves the PNG output

## Testing
- pytest tests/test_reporting_minimal.py::test_plot_coverage_accepts_time_objects


------
https://chatgpt.com/codex/tasks/task_e_68df99206f28832cae945b00527b0776