### PR TITLE
Support lexicographic objective mode for solver

### DIFF
--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -119,7 +119,20 @@ class PenaltiesConfig(BaseModel):
 class ObjectiveConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    # Modalità di combinazione degli obiettivi:
+    # - "weighted": somma pesata (comportamento attuale)
+    # - "lex": ottimizzazione lessicografica pura
+    mode: str = Field("weighted")
     priority: list[str] = Field(default_factory=lambda: list(PRIORITY_KEYS))
+
+    @field_validator("mode")
+    @classmethod
+    def validate_mode(cls, value: str) -> str:
+        value = value.strip().lower()
+        allowed = {"weighted", "lex"}
+        if value not in allowed:
+            raise ValueError(f"objective.mode deve essere uno tra {sorted(allowed)}")
+        return value
 
     @field_validator("priority")
     @classmethod

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,6 +133,7 @@ def build_solver_from_data(data_dir: Path, cfg: config_loader.Config) -> SimpleN
         mip_gap=cfg.solver.mip_gap,
         skills_slack_enabled=cfg.skills.enable_slack,
         objective_priority=tuple(objective_priority),
+        objective_mode=cfg.objective.mode,
     )
 
     solver = model_cp.ShiftSchedulingCpSolver(

--- a/tests/test_config_loader_basics.py
+++ b/tests/test_config_loader_basics.py
@@ -35,3 +35,11 @@ def test_load_config_custom(tmp_path: Path) -> None:
     assert cfg.rest.min_between_shifts == 10
     assert cfg.skills.enable_slack is False
     assert cfg.logging.level == "DEBUG"
+
+
+def test_objective_mode_validation() -> None:
+    cfg = config_loader.ObjectiveConfig()
+    assert cfg.mode == "weighted"
+    assert config_loader.ObjectiveConfig(mode="LEX").mode == "lex"
+    with pytest.raises(ValueError):
+        config_loader.ObjectiveConfig(mode="invalid")

--- a/tests/test_e2e_repo_data.py
+++ b/tests/test_e2e_repo_data.py
@@ -74,6 +74,7 @@ def test_e2e_solver_runs_on_repository_data():
         mip_gap=cfg.solver.mip_gap,
         skills_slack_enabled=cfg.skills.enable_slack,
         objective_priority=tuple(objective_priority),
+        objective_mode=cfg.objective.mode,
     )
 
     solver = model_cp.ShiftSchedulingCpSolver(

--- a/tests/test_overstaff.py
+++ b/tests/test_overstaff.py
@@ -127,6 +127,7 @@ def test_shift_overstaff_penalty(tmp_path: Path) -> None:
         mip_gap=cfg.solver.mip_gap,
         skills_slack_enabled=cfg.skills.enable_slack,
         objective_priority=tuple(objective_priority),
+        objective_mode=cfg.objective.mode,
     )
 
     solver = model_cp.ShiftSchedulingCpSolver(
@@ -223,6 +224,7 @@ def test_window_segment_overstaff_penalty(tmp_path: Path) -> None:
         mip_gap=cfg.solver.mip_gap,
         skills_slack_enabled=cfg.skills.enable_slack,
         objective_priority=tuple(objective_priority),
+        objective_mode=cfg.objective.mode,
     )
 
     solver = model_cp.ShiftSchedulingCpSolver(

--- a/tests/test_solver_modes.py
+++ b/tests/test_solver_modes.py
@@ -111,3 +111,22 @@ def test_coverage_source_shifts_uses_shift_requirement(tmp_path: Path) -> None:
     assert env.solver.shortfall_vars
     assert env.adaptive_data is None
 
+
+def test_solver_lex_mode_skips_zero_weight(tmp_path: Path) -> None:
+    data_dir = _build_dataset(tmp_path)
+
+    default_env = build_solver_from_data(data_dir, config_loader.Config())
+    default_keys = [key for key, _ in default_env.solver._collect_lex_stages()]
+    assert "unmet_window" in default_keys
+
+    cfg = config_loader.Config()
+    cfg.objective.mode = "lex"
+    cfg.penalties.unmet_window = 0.0
+
+    env = build_solver_from_data(data_dir, cfg)
+
+    assert env.solver.objective_mode == "lex"
+    stage_keys = [key for key, _ in env.solver._collect_lex_stages()]
+    assert stage_keys, "lex mode should still optimize at least one objective"
+    assert "unmet_window" not in stage_keys
+

--- a/tests/test_solver_window_skills.py
+++ b/tests/test_solver_window_skills.py
@@ -105,6 +105,7 @@ def test_solver_excludes_unskilled_workers(sample_environment):
         mip_gap=cfg.solver.mip_gap,
         skills_slack_enabled=cfg.skills.enable_slack,
         objective_priority=tuple(objective_priority),
+        objective_mode=cfg.objective.mode,
     )
 
     solver = model_cp.ShiftSchedulingCpSolver(
@@ -211,6 +212,7 @@ def test_shift_skill_requirements_parsed_from_string(sample_environment):
         mip_gap=cfg.solver.mip_gap,
         skills_slack_enabled=cfg.skills.enable_slack,
         objective_priority=tuple(objective_priority),
+        objective_mode=cfg.objective.mode,
     )
 
     solver = model_cp.ShiftSchedulingCpSolver(


### PR DESCRIPTION
## Summary
- add `objective.mode` to the configuration with validation
- allow the CP-SAT solver to run in weighted or lexicographic objective modes, including staged solving and hint warm starts
- update solver factories and tests to cover the new mode and ensure zero-weight objectives are skipped

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68dfa5128910832c81ab0a76642acf3d