### PR TITLE
Remove unused skill configuration toggles

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5,9 +5,7 @@ hours:
   max_overtime: 4
 rest:
   min_between_shifts: 8
-skills:
-  enable_slack: true
-  skill_mode: "by_shift"  # "by_shift" o "by_segment"
+ 
 shifts:
   demand_mode: "headcount"  # "headcount" | "person_minutes"
   coverage_source: "windows"  # "windows" | "shifts"

--- a/data/config.yaml
+++ b/data/config.yaml
@@ -7,9 +7,6 @@ hours:
 rest:
   min_between_shifts: 8
 
-skills:
-  enable_slack: true
-
 windows:
   coverage_mode: "adaptive_slots"
   enable_slot_slack: true

--- a/data/config_headcount.yaml
+++ b/data/config_headcount.yaml
@@ -5,8 +5,6 @@ hours:
   max_overtime: 4
 rest:
   min_between_shifts: 8
-skills:
-  enable_slack: true
 shifts:
   demand_mode: "headcount"  # ModalitÃ  persone simultanee
 penalties:

--- a/data/config_person_minutes.yaml
+++ b/data/config_person_minutes.yaml
@@ -5,8 +5,6 @@ hours:
   max_overtime: 4
 rest:
   min_between_shifts: 8
-skills:
-  enable_slack: true
 shifts:
   demand_mode: "person_minutes"  # ModalitÃ  volume di lavoro
 penalties:

--- a/dataset4/config.yaml
+++ b/dataset4/config.yaml
@@ -5,9 +5,7 @@ hours:
   max_overtime: 4
 rest:
   min_between_shifts: 8
-skills:
-  enable_slack: true
-  skill_mode: "by_shift"  # "by_shift" o "by_segment"
+ 
 shifts:
   demand_mode: "headcount"  # "headcount" | "person_minutes"
   coverage_source: "shifts"  # "windows" | "shifts"

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -48,18 +48,6 @@ class RestConfig(BaseModel):
 class SkillsConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    enable_slack: bool = True
-    skill_mode: str = Field("by_shift")
-
-    @field_validator("skill_mode")
-    @classmethod
-    def validate_skill_mode(cls, value: str) -> str:
-        modes = {"by_shift", "by_segment"}
-        value = value.strip().lower()
-        if value not in modes:
-            raise ValueError(f"skill_mode deve essere uno tra {sorted(modes)}")
-        return value
-
 class WindowsConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,7 +131,6 @@ def build_solver_from_data(data_dir: Path, cfg: config_loader.Config) -> SimpleN
         global_overtime_cap_minutes=None,
         random_seed=cfg.random.seed,
         mip_gap=cfg.solver.mip_gap,
-        skills_slack_enabled=cfg.skills.enable_slack,
         objective_priority=tuple(objective_priority),
         objective_mode=cfg.objective.mode,
     )

--- a/tests/test_config_loader_basics.py
+++ b/tests/test_config_loader_basics.py
@@ -13,7 +13,7 @@ def test_load_config_defaults(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -
     cfg = config_loader.load_config()
 
     assert cfg.hours.max_weekly == 40
-    assert cfg.skills.enable_slack is True
+    assert cfg.skills.model_dump() == {}
     assert cfg.objective.priority[0] == "unmet_window"
     assert list(cfg.objective.priority) == list(config_loader.PRIORITY_KEYS)
 
@@ -24,7 +24,6 @@ def test_load_config_custom(tmp_path: Path) -> None:
         {
             "hours": {"max_weekly": 50},
             "rest": {"min_between_shifts": 10},
-            "skills": {"enable_slack": False},
             "logging": {"level": "debug"},
         },
         cfg_path.open("w", encoding="utf-8"),
@@ -33,7 +32,6 @@ def test_load_config_custom(tmp_path: Path) -> None:
     cfg = config_loader.load_config(str(cfg_path))
     assert cfg.hours.max_weekly == 50
     assert cfg.rest.min_between_shifts == 10
-    assert cfg.skills.enable_slack is False
     assert cfg.logging.level == "DEBUG"
 
 

--- a/tests/test_e2e_repo_data.py
+++ b/tests/test_e2e_repo_data.py
@@ -72,7 +72,6 @@ def test_e2e_solver_runs_on_repository_data():
         global_overtime_cap_minutes=None,
         random_seed=cfg.random.seed,
         mip_gap=cfg.solver.mip_gap,
-        skills_slack_enabled=cfg.skills.enable_slack,
         objective_priority=tuple(objective_priority),
         objective_mode=cfg.objective.mode,
     )

--- a/tests/test_overstaff.py
+++ b/tests/test_overstaff.py
@@ -125,7 +125,6 @@ def test_shift_overstaff_penalty(tmp_path: Path) -> None:
         default_overtime_cost_weight=objective_weights.get('overtime', 0),
         random_seed=cfg.random.seed,
         mip_gap=cfg.solver.mip_gap,
-        skills_slack_enabled=cfg.skills.enable_slack,
         objective_priority=tuple(objective_priority),
         objective_mode=cfg.objective.mode,
     )
@@ -222,7 +221,6 @@ def test_window_segment_overstaff_penalty(tmp_path: Path) -> None:
         default_overtime_cost_weight=objective_weights.get('overtime', 0),
         random_seed=cfg.random.seed,
         mip_gap=cfg.solver.mip_gap,
-        skills_slack_enabled=cfg.skills.enable_slack,
         objective_priority=tuple(objective_priority),
         objective_mode=cfg.objective.mode,
     )

--- a/tests/test_solver_window_skills.py
+++ b/tests/test_solver_window_skills.py
@@ -103,7 +103,6 @@ def test_solver_excludes_unskilled_workers(sample_environment):
         global_overtime_cap_minutes=None,
         random_seed=cfg.random.seed,
         mip_gap=cfg.solver.mip_gap,
-        skills_slack_enabled=cfg.skills.enable_slack,
         objective_priority=tuple(objective_priority),
         objective_mode=cfg.objective.mode,
     )
@@ -159,8 +158,6 @@ def test_shift_skill_requirements_parsed_from_string(sample_environment):
 
     cfg = sample_environment.cfg
     cfg.shifts.coverage_source = "shifts"
-    cfg.skills.enable_slack = False
-
     (
         employees,
         shifts,
@@ -210,7 +207,6 @@ def test_shift_skill_requirements_parsed_from_string(sample_environment):
         global_overtime_cap_minutes=None,
         random_seed=cfg.random.seed,
         mip_gap=cfg.solver.mip_gap,
-        skills_slack_enabled=cfg.skills.enable_slack,
         objective_priority=tuple(objective_priority),
         objective_mode=cfg.objective.mode,
     )
@@ -236,6 +232,7 @@ def test_shift_skill_requirements_parsed_from_string(sample_environment):
 
     solver.demand_mode = cfg.shifts.demand_mode
     solver.build()
+    assert ("S1", "skillA") in solver.skill_shortfall_vars
     cp_solver = solver.solve()
 
     assert cp_solver.StatusName() == "OPTIMAL"


### PR DESCRIPTION
## Summary
- remove the unused skills configuration keys from the default YAML files and loader validation
- always build skill slack variables in the solver and refresh tests that previously toggled the flag

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2670afacc832ca8ffc1d4f39fb899