### PR TITLE
Avoid re-normalizing loader shift datetimes

### DIFF
--- a/src/precompute.py
+++ b/src/precompute.py
@@ -33,7 +33,15 @@ def normalize_shift_times(shifts: pd.DataFrame) -> pd.DataFrame:
       - start_dt, end_dt: datetime calcolati da day+start/end
       - duration_h: durata in ore (float)
     Regola: se end <= start, l'end si intende al giorno successivo (turno che "attraversa" le 24:00).
+
+    Se il DataFrame contiene già le colonne normalizzate (ad esempio quando proviene da
+    :func:`loader.load_shifts`), restituisce una copia senza ricalcolare i valori. La
+    logica sottostante rimane disponibile come fallback per dataset artigianali privi di
+    tali colonne.
     """
+    if {"start_dt", "end_dt", "duration_h"}.issubset(shifts.columns):
+        return shifts.copy()
+
     df = shifts.copy()
 
     def _mk_dt(day_obj, hhmm):

--- a/tests/test_loader_and_precompute.py
+++ b/tests/test_loader_and_precompute.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pandas as pd
+
 from src import loader, precompute
 
 
@@ -17,3 +19,14 @@ def test_loader_extracts_window_skills(sample_environment):
     key = next(iter(slots_in_window))
     assert slots_in_window[key], "each window should reference at least one slot"
     assert adaptive.slots_by_day_role, "adaptive slots must be generated"
+
+
+def test_normalize_shift_times_passthrough(sample_environment):
+    shifts = sample_environment.shifts
+
+    normalized = precompute.normalize_shift_times(shifts)
+
+    assert normalized is not shifts
+    pd.testing.assert_series_equal(normalized["start_dt"], shifts["start_dt"], check_names=False)
+    pd.testing.assert_series_equal(normalized["end_dt"], shifts["end_dt"], check_names=False)
+    pd.testing.assert_series_equal(normalized["duration_h"], shifts["duration_h"], check_names=False)


### PR DESCRIPTION
## Summary
- short-circuit `normalize_shift_times` when the loader has already populated normalized columns
- clarify the function docstring about the pass-through behavior for pre-normalized datasets
- add a regression test ensuring loader-provided shift data remains unchanged when normalized

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e292f0bce0832c951a37d54e97d883